### PR TITLE
example: download group, Component Cohesion Principles

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,3 +644,16 @@ In this project I use a Widget that does it automatically and also gets the imag
   }
   Widget build(BuildContext context) => cachedImage;
 ```
+
+## Example of adding new Download Group
+
+In this [example](https://github.com/bgoncharuck/ass_downloader_example/pull/10) I added new download group of the assets.
+
+The changes were done inside the `/models` component
+No other files were changed, but **new asset groups were correctly downloaded and showcased inside the app**.
+This demonstrates well-defined component boundaries where despite the limited code modifications, the newly added download group functioned as expected.
+
+The example adheres to the following component cohesion principles:
+- **Reuse/Release Equivalence Principle**: changes that affect the addition, removal, or modification of a download group are likely to be grouped together, promoting maintainability.
+- **Common Closure Principle**: the functionalities related to download group management are encapsulated within the /models component, fostering modularity.
+- **Common Reuse Principle**: the download group concept is likely to be reused for managing various asset groups within the application, reinforcing code reusability.

--- a/lib/models/download_groups/download_groups.dart
+++ b/lib/models/download_groups/download_groups.dart
@@ -1,8 +1,10 @@
 import 'package:ass_downloader_example/models/download_group.dart';
 import 'package:ass_downloader_example/models/download_groups/asian_animals/asian_animals.dart';
+import 'package:ass_downloader_example/models/download_groups/western_signs/western_signs.dart';
 
 Map<String, DownloadGroup> get downloadGroups {
   return {
     asianAnimals.name: asianAnimals,
+    westernSigns.name: westernSigns,
   };
 }

--- a/lib/models/download_groups/western_signs/aquarius.dart
+++ b/lib/models/download_groups/western_signs/aquarius.dart
@@ -1,0 +1,26 @@
+import 'package:ass_downloader_example/models/asset_group.dart';
+
+class AquariusAssetGroup extends ImageAssetGroup {
+  AquariusAssetGroup(String domain)
+      : super(
+          groupName: 'aquarius',
+          baseUrl: domain,
+          assets: [
+            white,
+            wood,
+            fire,
+            earth,
+            metal,
+            water,
+          ],
+          width: 120,
+          height: 120,
+        );
+
+  static const String white = 'assets/images/animal/aquarius/white.png';
+  static const String wood = 'assets/images/animal/aquarius/wood.png';
+  static const String fire = 'assets/images/animal/aquarius/fire.png';
+  static const String earth = 'assets/images/animal/aquarius/earth.png';
+  static const String metal = 'assets/images/animal/aquarius/metal.png';
+  static const String water = 'assets/images/animal/aquarius/water.png';
+}

--- a/lib/models/download_groups/western_signs/aries.dart
+++ b/lib/models/download_groups/western_signs/aries.dart
@@ -1,0 +1,26 @@
+import 'package:ass_downloader_example/models/asset_group.dart';
+
+class AriesAssetGroup extends ImageAssetGroup {
+  AriesAssetGroup(String domain)
+      : super(
+          groupName: 'aries',
+          baseUrl: domain,
+          assets: [
+            white,
+            wood,
+            fire,
+            earth,
+            metal,
+            water,
+          ],
+          width: 120,
+          height: 120,
+        );
+
+  static const String white = 'assets/images/animal/aries/white.png';
+  static const String wood = 'assets/images/animal/aries/wood.png';
+  static const String fire = 'assets/images/animal/aries/fire.png';
+  static const String earth = 'assets/images/animal/aries/earth.png';
+  static const String metal = 'assets/images/animal/aries/metal.png';
+  static const String water = 'assets/images/animal/aries/water.png';
+}

--- a/lib/models/download_groups/western_signs/cancer.dart
+++ b/lib/models/download_groups/western_signs/cancer.dart
@@ -1,0 +1,26 @@
+import 'package:ass_downloader_example/models/asset_group.dart';
+
+class CancerAssetGroup extends ImageAssetGroup {
+  CancerAssetGroup(String domain)
+      : super(
+          groupName: 'cancer',
+          baseUrl: domain,
+          assets: [
+            white,
+            wood,
+            fire,
+            earth,
+            metal,
+            water,
+          ],
+          width: 120,
+          height: 120,
+        );
+
+  static const String white = 'assets/images/animal/cancer/white.png';
+  static const String wood = 'assets/images/animal/cancer/wood.png';
+  static const String fire = 'assets/images/animal/cancer/fire.png';
+  static const String earth = 'assets/images/animal/cancer/earth.png';
+  static const String metal = 'assets/images/animal/cancer/metal.png';
+  static const String water = 'assets/images/animal/cancer/water.png';
+}

--- a/lib/models/download_groups/western_signs/capricorn.dart
+++ b/lib/models/download_groups/western_signs/capricorn.dart
@@ -1,0 +1,26 @@
+import 'package:ass_downloader_example/models/asset_group.dart';
+
+class CapricornAssetGroup extends ImageAssetGroup {
+  CapricornAssetGroup(String domain)
+      : super(
+          groupName: 'capricorn',
+          baseUrl: domain,
+          assets: [
+            white,
+            wood,
+            fire,
+            earth,
+            metal,
+            water,
+          ],
+          width: 120,
+          height: 120,
+        );
+
+  static const String white = 'assets/images/animal/capricorn/white.png';
+  static const String wood = 'assets/images/animal/capricorn/wood.png';
+  static const String fire = 'assets/images/animal/capricorn/fire.png';
+  static const String earth = 'assets/images/animal/capricorn/earth.png';
+  static const String metal = 'assets/images/animal/capricorn/metal.png';
+  static const String water = 'assets/images/animal/capricorn/water.png';
+}

--- a/lib/models/download_groups/western_signs/gemini.dart
+++ b/lib/models/download_groups/western_signs/gemini.dart
@@ -1,0 +1,26 @@
+import 'package:ass_downloader_example/models/asset_group.dart';
+
+class GeminiAssetGroup extends ImageAssetGroup {
+  GeminiAssetGroup(String domain)
+      : super(
+          groupName: 'gemini',
+          baseUrl: domain,
+          assets: [
+            white,
+            wood,
+            fire,
+            earth,
+            metal,
+            water,
+          ],
+          width: 120,
+          height: 120,
+        );
+
+  static const String white = 'assets/images/animal/gemini/white.png';
+  static const String wood = 'assets/images/animal/gemini/wood.png';
+  static const String fire = 'assets/images/animal/gemini/fire.png';
+  static const String earth = 'assets/images/animal/gemini/earth.png';
+  static const String metal = 'assets/images/animal/gemini/metal.png';
+  static const String water = 'assets/images/animal/gemini/water.png';
+}

--- a/lib/models/download_groups/western_signs/leo.dart
+++ b/lib/models/download_groups/western_signs/leo.dart
@@ -1,0 +1,26 @@
+import 'package:ass_downloader_example/models/asset_group.dart';
+
+class LeoAssetGroup extends ImageAssetGroup {
+  LeoAssetGroup(String domain)
+      : super(
+          groupName: 'leo',
+          baseUrl: domain,
+          assets: [
+            white,
+            wood,
+            fire,
+            earth,
+            metal,
+            water,
+          ],
+          width: 120,
+          height: 120,
+        );
+
+  static const String white = 'assets/images/animal/leo/white.png';
+  static const String wood = 'assets/images/animal/leo/wood.png';
+  static const String fire = 'assets/images/animal/leo/fire.png';
+  static const String earth = 'assets/images/animal/leo/earth.png';
+  static const String metal = 'assets/images/animal/leo/metal.png';
+  static const String water = 'assets/images/animal/leo/water.png';
+}

--- a/lib/models/download_groups/western_signs/libra.dart
+++ b/lib/models/download_groups/western_signs/libra.dart
@@ -1,0 +1,26 @@
+import 'package:ass_downloader_example/models/asset_group.dart';
+
+class LibraAssetGroup extends ImageAssetGroup {
+  LibraAssetGroup(String domain)
+      : super(
+          groupName: 'libra',
+          baseUrl: domain,
+          assets: [
+            white,
+            wood,
+            fire,
+            earth,
+            metal,
+            water,
+          ],
+          width: 120,
+          height: 120,
+        );
+
+  static const String white = 'assets/images/animal/libra/white.png';
+  static const String wood = 'assets/images/animal/libra/wood.png';
+  static const String fire = 'assets/images/animal/libra/fire.png';
+  static const String earth = 'assets/images/animal/libra/earth.png';
+  static const String metal = 'assets/images/animal/libra/metal.png';
+  static const String water = 'assets/images/animal/libra/water.png';
+}

--- a/lib/models/download_groups/western_signs/pisces.dart
+++ b/lib/models/download_groups/western_signs/pisces.dart
@@ -1,0 +1,26 @@
+import 'package:ass_downloader_example/models/asset_group.dart';
+
+class PiscesAssetGroup extends ImageAssetGroup {
+  PiscesAssetGroup(String domain)
+      : super(
+          groupName: 'pisces',
+          baseUrl: domain,
+          assets: [
+            white,
+            wood,
+            fire,
+            earth,
+            metal,
+            water,
+          ],
+          width: 120,
+          height: 120,
+        );
+
+  static const String white = 'assets/images/animal/pisces/white.png';
+  static const String wood = 'assets/images/animal/pisces/wood.png';
+  static const String fire = 'assets/images/animal/pisces/fire.png';
+  static const String earth = 'assets/images/animal/pisces/earth.png';
+  static const String metal = 'assets/images/animal/pisces/metal.png';
+  static const String water = 'assets/images/animal/pisces/water.png';
+}

--- a/lib/models/download_groups/western_signs/sagittarius.dart
+++ b/lib/models/download_groups/western_signs/sagittarius.dart
@@ -1,0 +1,26 @@
+import 'package:ass_downloader_example/models/asset_group.dart';
+
+class SagittariusAssetGroup extends ImageAssetGroup {
+  SagittariusAssetGroup(String domain)
+      : super(
+          groupName: 'sagittarius',
+          baseUrl: domain,
+          assets: [
+            white,
+            wood,
+            fire,
+            earth,
+            metal,
+            water,
+          ],
+          width: 120,
+          height: 120,
+        );
+
+  static const String white = 'assets/images/animal/sagittarius/white.png';
+  static const String wood = 'assets/images/animal/sagittarius/wood.png';
+  static const String fire = 'assets/images/animal/sagittarius/fire.png';
+  static const String earth = 'assets/images/animal/sagittarius/earth.png';
+  static const String metal = 'assets/images/animal/sagittarius/metal.png';
+  static const String water = 'assets/images/animal/sagittarius/water.png';
+}

--- a/lib/models/download_groups/western_signs/scorpio.dart
+++ b/lib/models/download_groups/western_signs/scorpio.dart
@@ -1,0 +1,26 @@
+import 'package:ass_downloader_example/models/asset_group.dart';
+
+class ScorpioAssetGroup extends ImageAssetGroup {
+  ScorpioAssetGroup(String domain)
+      : super(
+          groupName: 'scorpio',
+          baseUrl: domain,
+          assets: [
+            white,
+            wood,
+            fire,
+            earth,
+            metal,
+            water,
+          ],
+          width: 120,
+          height: 120,
+        );
+
+  static const String white = 'assets/images/animal/scorpio/white.png';
+  static const String wood = 'assets/images/animal/scorpio/wood.png';
+  static const String fire = 'assets/images/animal/scorpio/fire.png';
+  static const String earth = 'assets/images/animal/scorpio/earth.png';
+  static const String metal = 'assets/images/animal/scorpio/metal.png';
+  static const String water = 'assets/images/animal/scorpio/water.png';
+}

--- a/lib/models/download_groups/western_signs/taurus.dart
+++ b/lib/models/download_groups/western_signs/taurus.dart
@@ -1,0 +1,26 @@
+import 'package:ass_downloader_example/models/asset_group.dart';
+
+class TaurusAssetGroup extends ImageAssetGroup {
+  TaurusAssetGroup(String domain)
+      : super(
+          groupName: 'taurus',
+          baseUrl: domain,
+          assets: [
+            white,
+            wood,
+            fire,
+            earth,
+            metal,
+            water,
+          ],
+          width: 120,
+          height: 120,
+        );
+
+  static const String white = 'assets/images/animal/taurus/white.png';
+  static const String wood = 'assets/images/animal/taurus/wood.png';
+  static const String fire = 'assets/images/animal/taurus/fire.png';
+  static const String earth = 'assets/images/animal/taurus/earth.png';
+  static const String metal = 'assets/images/animal/taurus/metal.png';
+  static const String water = 'assets/images/animal/taurus/water.png';
+}

--- a/lib/models/download_groups/western_signs/virgo.dart
+++ b/lib/models/download_groups/western_signs/virgo.dart
@@ -1,0 +1,26 @@
+import 'package:ass_downloader_example/models/asset_group.dart';
+
+class VirgoAssetGroup extends ImageAssetGroup {
+  VirgoAssetGroup(String domain)
+      : super(
+          groupName: 'virgo',
+          baseUrl: domain,
+          assets: [
+            white,
+            wood,
+            fire,
+            earth,
+            metal,
+            water,
+          ],
+          width: 120,
+          height: 120,
+        );
+
+  static const String white = 'assets/images/animal/virgo/white.png';
+  static const String wood = 'assets/images/animal/virgo/wood.png';
+  static const String fire = 'assets/images/animal/virgo/fire.png';
+  static const String earth = 'assets/images/animal/virgo/earth.png';
+  static const String metal = 'assets/images/animal/virgo/metal.png';
+  static const String water = 'assets/images/animal/virgo/water.png';
+}

--- a/lib/models/download_groups/western_signs/western_signs.dart
+++ b/lib/models/download_groups/western_signs/western_signs.dart
@@ -1,0 +1,46 @@
+import 'package:ass_downloader_example/models/asset_group.dart';
+import 'package:ass_downloader_example/models/download_group.dart';
+import 'package:ass_downloader_example/models/download_groups/western_signs/aquarius.dart';
+import 'package:ass_downloader_example/models/download_groups/western_signs/aries.dart';
+import 'package:ass_downloader_example/models/download_groups/western_signs/cancer.dart';
+import 'package:ass_downloader_example/models/download_groups/western_signs/capricorn.dart';
+import 'package:ass_downloader_example/models/download_groups/western_signs/gemini.dart';
+import 'package:ass_downloader_example/models/download_groups/western_signs/leo.dart';
+import 'package:ass_downloader_example/models/download_groups/western_signs/libra.dart';
+import 'package:ass_downloader_example/models/download_groups/western_signs/pisces.dart';
+import 'package:ass_downloader_example/models/download_groups/western_signs/sagittarius.dart';
+import 'package:ass_downloader_example/models/download_groups/western_signs/scorpio.dart';
+import 'package:ass_downloader_example/models/download_groups/western_signs/taurus.dart';
+import 'package:ass_downloader_example/models/download_groups/western_signs/virgo.dart';
+
+final westernSigns = WesternSigns();
+
+/// download group of the image asset groups
+/// dedicated to the western astrology signs
+class WesternSigns implements DownloadGroup {
+  @override
+  String get name => 'Western Signs';
+
+  @override
+  Map<String, AssetGroup> assets = {};
+
+  @override
+  void init(String domain) {
+    assets.addAll({
+      /// image asset groups
+      'aquarius': AquariusAssetGroup(domain),
+      'pisces': PiscesAssetGroup(domain),
+      'aries': AriesAssetGroup(domain),
+      'taurus': TaurusAssetGroup(domain),
+      'gemini': GeminiAssetGroup(domain),
+      'cancer': CancerAssetGroup(domain),
+      'leo': LeoAssetGroup(domain),
+      'virgo': VirgoAssetGroup(domain),
+      'libra': LibraAssetGroup(domain),
+      'scorpio': ScorpioAssetGroup(domain),
+      'sagittarius': SagittariusAssetGroup(domain),
+      'capricorn': CapricornAssetGroup(domain),
+    });
+    //
+  }
+}


### PR DESCRIPTION
In this example I added new download group of the assets.
The changes were done inside the `/models` component
No other files were changed, but **new asset groups were correctly downloaded and showcased inside the app**.
This demonstrates well-defined component boundaries where despite the limited code modifications, the newly added download group functioned as expected.

The example adheres to the following component cohesion principles:
- **Reuse/Release Equivalence Principle**: changes that affect the addition, removal, or modification of a download group are likely to be grouped together, promoting maintainability.
- **Common Closure Principle**: the functionalities related to download group management are encapsulated within the /models component, fostering modularity.
- **Common Reuse Principle**: the download group concept is likely to be reused for managing various asset groups within the application, reinforcing code reusability.